### PR TITLE
fix: make limited status return limited instead of granted => main

### DIFF
--- a/ios/Sources/CapacitorContactsPlugin/CapacitorContactsPlugin.swift
+++ b/ios/Sources/CapacitorContactsPlugin/CapacitorContactsPlugin.swift
@@ -493,8 +493,10 @@ public class CapacitorContactsPlugin: CAPPlugin, CAPBridgedPlugin {
 
     private func mapAuthorizationStatus(_ status: CNAuthorizationStatus) -> String {
         switch status {
-        case .authorized, .limited:
+        case .authorized:
             return "granted"
+        case .limited:
+            return "limited"
         case .denied:
             return "denied"
         case .restricted:


### PR DESCRIPTION
**Problem**
On iOS 18+, users can grant "limited" contacts access, which restricts the app to only a subset of their contacts. However, in mapAuthorizationStatus, both .authorized and .limited were grouped into the same case and returned "granted". This made it impossible for JS/TS consumers to detect whether the user had granted full or limited access.
The ContactsPermissionState TypeScript type already included 'limited' as a valid value, but the native code never actually returned it, making it dead type definition.

**Fix**
Split .limited into its own case in mapAuthorizationStatus, returning "limited" instead of "granted", so the permission state is accurately surfaced to the JS layer.

**Testing**
On iOS 18+, request contacts permission and select "Limited Access" -> checkPermissions() should now return "limited" for readContacts.
Granting full access should still return "granted" as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed permission status handling to properly distinguish between full and limited access to contacts, allowing the app to accurately reflect authorization levels when requesting contact permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->