### PR TITLE
fix(android): register activity result request codes in plugin annota…

### DIFF
--- a/android/src/main/java/app/capgo/contacts/CapacitorContactsPlugin.java
+++ b/android/src/main/java/app/capgo/contacts/CapacitorContactsPlugin.java
@@ -35,7 +35,8 @@ import java.util.Set;
     permissions = {
         @Permission(alias = "readContacts", strings = { Manifest.permission.READ_CONTACTS }),
         @Permission(alias = "writeContacts", strings = { Manifest.permission.WRITE_CONTACTS })
-    }
+    },
+    requestCodes = { 7001, 7003 }
 )
 public class CapacitorContactsPlugin extends Plugin {
 


### PR DESCRIPTION
## Problem
`pickContact` and `displayCreateContact` hang indefinitely on Android with no error thrown.

## Cause
`PICK_CONTACT_REQUEST` (7001) and `CREATE_CONTACT_REQUEST` (7003) were missing 
from the `requestCodes` field in the `@CapacitorPlugin` annotation in 
`android/src/main/java/ee/forgr/capacitor/contacts/ContactsPlugin.java`.

Without this, Capacitor's bridge never routes the activity result back to 
`handleOnActivityResult`, so the promise never resolves.

## Fix
Added the missing request codes to the `@CapacitorPlugin` annotation in `ContactsPlugin.java`:

```java
@CapacitorPlugin(
    name = "CapacitorContacts",
    permissions = {
        @Permission(alias = "readContacts", strings = { Manifest.permission.READ_CONTACTS }),
        @Permission(alias = "writeContacts", strings = { Manifest.permission.WRITE_CONTACTS })
    },
    requestCodes = { 7001, 7003 }
)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Android plugin configuration to improve handling of permission request results on Android devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->